### PR TITLE
Avoid infinite reminder comments

### DIFF
--- a/reminder/reminder.go
+++ b/reminder/reminder.go
@@ -196,7 +196,7 @@ func (c *InstallationClient) checkReminders(ctx context.Context, issue *issue) e
 
 	check := func(author, body string) error {
 		for _, reminder := range findTimes("reminder", body) {
-			now := time.Now()
+			now := time.Now().In(time.UTC)
 			// not the same day
 			if reminder.Day() != now.Day() || reminder.Month() != now.Month() || reminder.Year() != now.Year() {
 				continue

--- a/reminder/reminder.go
+++ b/reminder/reminder.go
@@ -196,7 +196,9 @@ func (c *InstallationClient) checkReminders(ctx context.Context, issue *issue) e
 
 	check := func(author, body string) error {
 		for _, reminder := range findTimes("reminder", body) {
-			if diff := time.Until(reminder); diff > 24*time.Hour || diff < -24*time.Hour {
+			now := time.Now()
+			// not the same day
+			if reminder.Day() != now.Day() || reminder.Month() != now.Month() || reminder.Year() != now.Year() {
 				continue
 			}
 

--- a/reminder/reminder_test.go
+++ b/reminder/reminder_test.go
@@ -100,6 +100,7 @@ func TestAvoidAddingSecondReminderComment(t *testing.T) {
 	ic := InstallationClient{42, 43, &fakeClient{
 		_repoLabels: func(ctx context.Context, owner, repo string) ([]string, error) { return nil, nil },
 		_issue: func(ctx context.Context, owner, repo string, number int) (*issue, error) {
+			now := time.Now()
 			return &issue{
 				repo:   repository{owner, repo},
 				number: number,
@@ -110,11 +111,12 @@ func TestAvoidAddingSecondReminderComment(t *testing.T) {
 				comments: []comment{{
 					author:  "francesc",
 					body:    fmt.Sprintf("reminder: %s\n", time.Now().Format("2006-01-02")),
-					created: time.Now().Add(-96 * time.Hour),
+					created: now.Add(-96 * time.Hour),
 				}, {
-					author:  "deadline-reminder[bot]",
-					body:    "hi @francesc, it's reminder time!",
-					created: time.Now().Add(-24 * time.Hour),
+					author: "deadline-reminder[bot]",
+					body:   "hi @francesc, it's reminder time!",
+					// 1 am today
+					created: time.Date(now.Year(), now.Month(), now.Day(), 1, 0, 0, 0, now.Location()),
 				}},
 			}, nil
 		},


### PR DESCRIPTION
The condition for diff > 24*Hours || diff < -24*Hours breaks when
crossing day bounderies. The date of the posted reminder is before the
day that it parses as deadline and thus it doesn't match when it's
searching for it at line 207.

When we ensure we are only looking for reminders for the same day we are
not allowing it to cross the day and will always match against the
current date

Fixes #14 